### PR TITLE
ci: enable publish to npm

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,5 +1,4 @@
 {
-  "onlyPublishWithReleaseLabel": true,
   "plugins": [
     "npm",
     [

--- a/.autorc
+++ b/.autorc
@@ -1,4 +1,5 @@
 {
+  "onlyPublishWithReleaseLabel": true,
   "plugins": [
     "npm",
     [

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pchalupa

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,14 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+      - run: git fetch --unshallow --tags
       - uses: actions/setup-node@v3
         with:
           node-version: 20
       - run: npm ci
       - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx auto shipit --dry-run
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx auto shipit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/expo-alternate-app-icons
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
-# Exclude all top-level hidden directories by convention
 /.*/
+/.*
 
 __mocks__
 __tests__
@@ -9,4 +9,3 @@ __tests__
 /android/src/test/
 /android/build/
 /example/
-/.github/


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.1--canary.1.aa9e77d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install expo-alternate-app-icons@0.1.1--canary.1.aa9e77d.0
  # or 
  yarn add expo-alternate-app-icons@0.1.1--canary.1.aa9e77d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
