### PR TITLE
refactor: build property constant

### DIFF
--- a/plugin/src/withXcodeProjectUpdate.ts
+++ b/plugin/src/withXcodeProjectUpdate.ts
@@ -1,14 +1,17 @@
 import { type ExpoConfig } from '@expo/config-types';
 import { withXcodeProject } from 'expo/config-plugins';
 
+const ALTERNATE_APP_ICONS_NAMES_PROPERTY = 'ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES';
+
 export function withXcodeProjectUpdate(
   config: ExpoConfig,
   alternateAppIconNames: Set<string>,
 ): ExpoConfig {
   config = withXcodeProject(config, (config) => {
-    const property = 'ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES';
-
-    config.modResults.updateBuildProperty(property, Array.from(alternateAppIconNames));
+    config.modResults.updateBuildProperty(
+      ALTERNATE_APP_ICONS_NAMES_PROPERTY,
+      Array.from(alternateAppIconNames),
+    );
 
     return config;
   });


### PR DESCRIPTION
Minor refactor of `withXcodeProjectUpdate` function.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.5--canary.19.87c45e3.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install expo-alternate-app-icons@0.1.5--canary.19.87c45e3.0
  # or 
  yarn add expo-alternate-app-icons@0.1.5--canary.19.87c45e3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
