### PR TITLE
feat: reset app icon function

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ function getAppIconName(): string | null;
 
 #### Reset App Icon
 
-To reset app icon to the default one.
+Reset app icon to the default one.
+
+> This is just a shortcut for `setAlternateAppIcon(null)`.
 
 ```ts
 function resetAppIcon(): Promise<void>;

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ Your icons should follow the same format as your [default app icon](https://docs
 
 ### API Documentation
 
+#### Supports Alternate Icons
+
+A boolean value indicating whether the current device supports alternate app icons.
+
+```ts
+const supportsAlternateIcons: boolean;
+```
+
 #### Set Alternate App Icon
 
 To set app icon to **icon-a.png**, use `setAlternateAppIcon("icon-a")`. This function takes exact icon name without suffix.
@@ -64,7 +72,7 @@ To set app icon to **icon-a.png**, use `setAlternateAppIcon("icon-a")`. This fun
 To reset the app icon to the default pass `null` like `setAlternateAppIcon(null)`.
 
 ```ts
-function setAlternateAppIcon(name: string | null): Promise<string>;
+function setAlternateAppIcon(name: string | null): Promise<string | null>;
 ```
 
 #### Get App Icon Name
@@ -72,13 +80,13 @@ function setAlternateAppIcon(name: string | null): Promise<string>;
 Retrieves the name of the currently active app icon.
 
 ```ts
-function getAppIconName(): string;
+function getAppIconName(): string | null;
 ```
 
-#### Supports Alternate Icons
+#### Reset App Icon
 
-A boolean value indicating whether the current device supports alternate app icons.
+To reset app icon to the default one.
 
 ```ts
-const supportsAlternateIcons: boolean;
+function resetAppIcon(): Promise<void>;
 ```

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,6 @@
 import {
   setAlternateAppIcon,
+  resetAppIcon,
   getAppIconName,
   supportsAlternateIcons,
 } from 'expo-alternate-app-icons';
@@ -13,10 +14,10 @@ import { Button } from './src/Button';
 import { IconButton } from './src/IconButton';
 
 export default function App() {
-  const [currentAppIconName, setCurrentAppIconName] = useState(getAppIconName());
+  const [currentAppIconName, setCurrentAppIconName] = useState<string | null>(getAppIconName());
 
   const handleSetAppIcon = useCallback(
-    async (iconName: string | null) => {
+    async (iconName: string) => {
       try {
         const newAppIconName = await setAlternateAppIcon(iconName);
 
@@ -28,7 +29,15 @@ export default function App() {
     [setCurrentAppIconName],
   );
 
-  const handleReset = useCallback(() => handleSetAppIcon(null), [handleSetAppIcon]);
+  const handleReset = useCallback(async () => {
+    try {
+      await resetAppIcon();
+
+      setCurrentAppIconName(null);
+    } catch (error) {
+      if (error instanceof Error) Alert.alert('Error', error.message);
+    }
+  }, [setCurrentAppIconName]);
 
   return (
     <SafeAreaView style={styles.container}>

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export const supportsAlternateIcons: boolean = ExpoAlternateAppIconsModule.suppo
  * const resetResult = await setAlternateAppIcon(null);
  */
 export async function setAlternateAppIcon(name: string | null): Promise<string | null> {
-  return await ExpoAlternateAppIconsModule.setAlternateAppIcon(name);
+  return ExpoAlternateAppIconsModule.setAlternateAppIcon(name);
 }
 
 /**
@@ -54,5 +54,5 @@ export function getAppIconName(): string | null {
  * @throws {Error} Throws an error if there is an issue with setting the alternate app icon.
  */
 export async function resetAppIcon(): Promise<void> {
-  await ExpoAlternateAppIconsModule.setAlternateAppIcon(null);
+  await setAlternateAppIcon(null);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export const supportsAlternateIcons: boolean = ExpoAlternateAppIconsModule.suppo
  * Sets the alternate app icon for the application.
  *
  * @param {string | null} name - The name of the alternate app icon to set. Pass `null` to reset to the default icon.
- * @returns {Promise<string>} A Promise that resolves to a icon name.
+ * @returns {Promise<string | null>} A Promise that resolves to a icon name.
  * @throws {Error} Throws an error if there is an issue with setting the alternate app icon.
  *
  * @example
@@ -29,20 +29,30 @@ export const supportsAlternateIcons: boolean = ExpoAlternateAppIconsModule.suppo
  * // Reset to the default app icon.
  * const resetResult = await setAlternateAppIcon(null);
  */
-export async function setAlternateAppIcon(name: string | null): Promise<string> {
+export async function setAlternateAppIcon(name: string | null): Promise<string | null> {
   return await ExpoAlternateAppIconsModule.setAlternateAppIcon(name);
 }
 
 /**
  * Retrieves the name of the currently active app icon.
  *
- * @returns {string} The name of the currently active app icon.
+ * @returns {string | null} The name of the currently active app icon.
  *
  * @example
  * // Get the name of the currently active app icon.
  * const iconName = getAppIconName();
  * console.log(`The active app icon is: ${iconName}`);
  */
-export function getAppIconName(): string {
+export function getAppIconName(): string | null {
   return ExpoAlternateAppIconsModule.getAppIconName();
+}
+
+/**
+ * Resets the app icon to the default one.
+ *
+ * @returns {Promise<void>}
+ * @throws {Error} Throws an error if there is an issue with setting the alternate app icon.
+ */
+export async function resetAppIcon(): Promise<void> {
+  await ExpoAlternateAppIconsModule.setAlternateAppIcon(null);
 }


### PR DESCRIPTION
Adding `resetAppIcon()` which is a shortcut for `setAlternateAppIcon(null)`. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.6--canary.26.a270d18.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install expo-alternate-app-icons@0.1.6--canary.26.a270d18.0
  # or 
  yarn add expo-alternate-app-icons@0.1.6--canary.26.a270d18.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
