### PR TITLE
refactor: run task on main thread

### DIFF
--- a/ios/ExpoAlternateAppIconsModule.swift
+++ b/ios/ExpoAlternateAppIconsModule.swift
@@ -21,7 +21,7 @@ public class ExpoAlternateAppIconsModule: Module {
     }
 
     private func setAlternateAppIcon(icon: String?, promise: Promise) -> Void {
-        Task {
+        Task { @MainActor in
             do {
                 try await UIApplication.shared.setAlternateIconName(icon);
 


### PR DESCRIPTION
Solves this warning:
```
UIApplication.setAlternateIconName(_:completionHandler:) must be used from main thread only
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.7--canary.36.d286558.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install expo-alternate-app-icons@0.1.7--canary.36.d286558.0
  # or 
  yarn add expo-alternate-app-icons@0.1.7--canary.36.d286558.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
