### PR TITLE
ci: fix publish job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,8 @@ jobs:
       url: https://www.npmjs.com/package/expo-alternate-app-icons
     steps:
       - run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config --global user.name github-actions
+          git config --global user.email github-actions@github.com
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       url: https://www.npmjs.com/package/expo-alternate-app-icons
     steps:
       - run: |
-          git config --global --add url."git@github.com:".insteadOf "https://github.com/"
+          git config --global credential.https://github.com.username pchalupa
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
       name: npm
       url: https://www.npmjs.com/package/expo-alternate-app-icons
     steps:
+      - run: |
+          git config --global --add url."git@github.com:".insteadOf "https://github.com/"
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,7 @@ jobs:
       name: npm
       url: https://www.npmjs.com/package/expo-alternate-app-icons
     steps:
-      - run: |
-          git config --global credential.https://github.com.username pchalupa
+      - run: git config --global user.name "pchalupa"
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,9 @@ jobs:
       name: npm
       url: https://www.npmjs.com/package/expo-alternate-app-icons
     steps:
-      - run: git config --global user.name "pchalupa"
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Fixed git checkout action in the publish job.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.8--canary.69.ac85c14.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install expo-alternate-app-icons@0.1.8--canary.69.ac85c14.0
  # or 
  yarn add expo-alternate-app-icons@0.1.8--canary.69.ac85c14.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
