### PR TITLE
ci(publish): fix failing pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,12 @@ jobs:
       name: npm
       url: https://www.npmjs.com/package/expo-alternate-app-icons
     steps:
-      - run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
       - run: git fetch --unshallow --tags
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,8 @@ jobs:
       url: https://www.npmjs.com/package/expo-alternate-app-icons
     steps:
       - run: |
-          git config --global user.name github-actions
-          git config --global user.email github-actions@github.com
+          git config user.name github-actions
+          git config user.email github-actions@github.com
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.10--canary.94.697fcfe.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install expo-alternate-app-icons@0.1.10--canary.94.697fcfe.0
  # or 
  yarn add expo-alternate-app-icons@0.1.10--canary.94.697fcfe.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
