### PR TITLE
fix(android): handle fully qualified name for activity classes

### DIFF
--- a/android/src/main/java/expo/modules/alternateappicons/ExpoAlternateAppIconsModule.kt
+++ b/android/src/main/java/expo/modules/alternateappicons/ExpoAlternateAppIconsModule.kt
@@ -35,9 +35,7 @@ class ExpoAlternateAppIconsModule : Module() {
 
     if (currentIconName == icon) return@withContext icon
 
-    val newActivityName = "$MAIN_ACTIVITY_NAME${icon ?: ""}"
-    val packageName = currentActivityComponent.packageName
-    val newActivityComponent = ComponentName(packageName, "$packageName.$newActivityName")
+    val newActivityComponent = replaceMainActivitySimpleName(currentActivityComponent, icon)
 
     appContext.reactContext?.packageManager?.run {
       setComponentEnabledSetting(newActivityComponent, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP)
@@ -57,5 +55,14 @@ class ExpoAlternateAppIconsModule : Module() {
         else -> null
       }
     }
+
+  private fun replaceMainActivitySimpleName(component: ComponentName, suffix: String?): ComponentName {
+    val newActivitySimpleName = "$MAIN_ACTIVITY_NAME${suffix ?: ""}"
+    val identifiers = component.className.split('.').toMutableList()
+    identifiers[identifiers.size - 1] = newActivitySimpleName
+    val packageName = component.packageName
+    val newActivityName = identifiers.joinToString(".")
+    return ComponentName(packageName, newActivityName)
+  }
 
 }

--- a/android/src/main/java/expo/modules/alternateappicons/ExpoAlternateAppIconsModule.kt
+++ b/android/src/main/java/expo/modules/alternateappicons/ExpoAlternateAppIconsModule.kt
@@ -2,14 +2,13 @@ package expo.modules.alternateappicons
 
 import android.content.ComponentName
 import android.content.pm.PackageManager
-import expo.modules.kotlin.Promise
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-const val MAIN_ACTIVITY_NAME = ".MainActivity"
+const val MAIN_ACTIVITY_NAME = "MainActivity"
 
 class ExpoAlternateAppIconsModule : Module() {
   override fun definition() = ModuleDefinition {
@@ -24,24 +23,21 @@ class ExpoAlternateAppIconsModule : Module() {
   }
 
   private fun getAppIconName(): String? {
-    val activityName = appContext.activityProvider?.currentActivity?.componentName?.shortClassName
+    val currentActivityComponent = appContext.activityProvider!!.currentActivity!!.componentName!!
 
-    if(activityName !== null && !activityName.startsWith(MAIN_ACTIVITY_NAME) || activityName == MAIN_ACTIVITY_NAME) return null
-
-    return activityName?.substring(MAIN_ACTIVITY_NAME.length)
+    return retrieveIconNameFromComponent(currentActivityComponent)
   }
 
   private suspend fun setAlternateAppIcon(icon: String?): String? = withContext(Dispatchers.Main) {
-    val currentActivityComponent = appContext.activityProvider?.currentActivity?.componentName
+    val currentActivityComponent = appContext.activityProvider!!.currentActivity!!.componentName
 
-    if (currentActivityComponent == null || !currentActivityComponent.shortClassName.startsWith(MAIN_ACTIVITY_NAME)) return@withContext null
+    val currentIconName = retrieveIconNameFromComponent(currentActivityComponent)
+
+    if (currentIconName == icon) return@withContext icon
 
     val newActivityName = "$MAIN_ACTIVITY_NAME${icon ?: ""}"
-
-    if (currentActivityComponent.shortClassName == newActivityName) return@withContext icon
-
-    val packageName = currentActivityComponent.packageName;
-    val newActivityComponent = ComponentName(packageName, "$packageName$newActivityName")
+    val packageName = currentActivityComponent.packageName
+    val newActivityComponent = ComponentName(packageName, "$packageName.$newActivityName")
 
     appContext.reactContext?.packageManager?.run {
       setComponentEnabledSetting(newActivityComponent, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP)
@@ -50,4 +46,16 @@ class ExpoAlternateAppIconsModule : Module() {
 
     return@withContext icon
   }
+
+  private fun getSimpleName(component: ComponentName): String = component.className.split('.').last()
+
+  private fun retrieveIconNameFromComponent(component: ComponentName): String? =
+    with(getSimpleName(component)) {
+      when  {
+        equals(MAIN_ACTIVITY_NAME) -> null
+        startsWith(MAIN_ACTIVITY_NAME) -> substring(MAIN_ACTIVITY_NAME.length)
+        else -> null
+      }
+    }
+
 }


### PR DESCRIPTION
Fully Qualified Class Names in Activities cause an unrecognized icon name on Android Release Build.
This PR splits the class name in the Kotlin module and uses only the last segment (Simple Name).

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.2--canary.107.2355084.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install expo-alternate-app-icons@1.0.2--canary.107.2355084.0
  # or 
  yarn add expo-alternate-app-icons@1.0.2--canary.107.2355084.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
