### PR TITLE
chore: bump expo-modules-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To get started, install the library using Expo CLI:
 npx expo install expo-alternate-app-icons
 ```
 
-> Ensure your project is running Expo SDK 44+.
+> Ensure your project is running Expo SDK 51+.
 
 ## How To Use
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,17 @@
       "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
-        "@auto-it/conventional-commits": "^11.0.4",
-        "@auto-it/npm": "^11.0.4",
-        "@types/fs-extra": "^11.0.4",
-        "auto": "^11.0.4",
-        "expo-module-scripts": "^3.4.1",
-        "expo-modules-core": "^1.11.8",
+        "@auto-it/conventional-commits": "^11.3.0",
+        "@auto-it/npm": "^11.3.0",
+        "auto": "^11.3.0",
+        "expo-module-scripts": "^3.5.2",
+        "expo-modules-core": "^1.12.26",
         "prettier": "^3.2.5"
       },
       "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
+        "expo": ">=51",
+        "react": ">=18.2.0",
+        "react-native": ">=0.74.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6290,16 +6289,6 @@
       "integrity": "sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg==",
       "dev": true
     },
-    "node_modules/@types/fs-extra": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
-      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.7.tgz",
@@ -6394,15 +6383,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "node_modules/@types/jsonfile": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
-      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -29,17 +29,16 @@
     "open:android": "open -a \"Android Studio\" example/android"
   },
   "devDependencies": {
-    "@auto-it/conventional-commits": "^11.0.4",
-    "@auto-it/npm": "^11.0.4",
-    "@types/fs-extra": "^11.0.4",
-    "auto": "^11.0.4",
-    "expo-module-scripts": "^3.4.1",
-    "expo-modules-core": "^1.11.8",
+    "@auto-it/conventional-commits": "^11.3.0",
+    "@auto-it/npm": "^11.3.0",
+    "auto": "^11.3.0",
+    "expo-module-scripts": "^3.5.2",
+    "expo-modules-core": "^1.12.26",
     "prettier": "^3.2.5"
   },
   "peerDependencies": {
-    "expo": "*",
-    "react": "*",
-    "react-native": "*"
+    "expo": ">=51",
+    "react": ">=18.2.0",
+    "react-native": ">=0.74.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "expo": ">=51",
-    "react": ">=18.2.0",
-    "react-native": ">=0.74.5"
+    "react": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
#112 bumps expo-modules-core to the latest version adds https://github.com/expo/expo/blob/d1457e99c0432b1e1c9e044ba87d9cd7f7f1fef3/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle#L54 