### PR TITLE
Add support for dark and tinted icon variants on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ This package contains an Expo Plugin that copies your alternative icons to nativ
       [
         {
           "name": "IconA", // The name of the alternate icon
-          "ios": "./assets/icon-a.png", // Path to the iOS app icon
+          "ios": {
+            "light":"./assets/icon-a.png",
+            "dark":"./assets/icon-a-dark.png",
+            "tinted":"./assets/icon-a-tinted.png"
+          }, // Path to the iOS app icons or if you do not want to use the variants enter directly the path
           "android": {
             "foregroundImage": "./assets/icon-a-foreground.png", // Path to Android foreground image
             "backgroundColor": "#001413" // Background color for Android adaptive icon
@@ -55,7 +59,7 @@ This package contains an Expo Plugin that copies your alternative icons to nativ
         },
         {
           "name": "IconB",
-          "ios": "./assets/icon-b.png",
+          "ios": "./assets/icon-b.png",  // Without variants,
           "android": {
             "foregroundImage": "./assets/icon-b-foreground.png",
             "backgroundColor": "#001413"

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -12,12 +12,13 @@ import { icons } from './App.preset';
 import { styles } from './App.styles';
 import { Button } from './src/Button';
 import { IconButton } from './src/IconButton';
+import { AlternateAppIcons } from 'expo-alternate-app-icons/AlternateAppIconsType';
 
 export default function App() {
   const [currentAppIconName, setCurrentAppIconName] = useState<string | null>(getAppIconName());
 
   const handleSetAppIcon = useCallback(
-    async (iconName: string) => {
+    async (iconName: AlternateAppIcons) => {
       try {
         const newAppIconName = await setAlternateAppIcon(iconName);
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -3,6 +3,7 @@ import {
   resetAppIcon,
   getAppIconName,
   supportsAlternateIcons,
+  type AlternateAppIcons,
 } from 'expo-alternate-app-icons';
 import { StatusBar } from 'expo-status-bar';
 import { useCallback, useState } from 'react';
@@ -12,7 +13,6 @@ import { icons } from './App.preset';
 import { styles } from './App.styles';
 import { Button } from './src/Button';
 import { IconButton } from './src/IconButton';
-import { AlternateAppIcons } from 'expo-alternate-app-icons/AlternateAppIconsType';
 
 export default function App() {
   const [currentAppIconName, setCurrentAppIconName] = useState<string | null>(getAppIconName());

--- a/example/app.json
+++ b/example/app.json
@@ -32,7 +32,11 @@
         [
           {
             "name": "IconA",
-            "ios": "./assets/icon-a.png",
+            "ios":{
+              "light": "./assets/icon-a.png",
+              "dark": "./assets/icon-b.png",
+              "tinted": "./assets/icon-c.png"
+            },
             "android": {
               "foregroundImage": "./assets/icon-a-foreground.png",
               "backgroundColor": "#001413"

--- a/example/src/IconButton.tsx
+++ b/example/src/IconButton.tsx
@@ -2,11 +2,12 @@ import { useCallback } from 'react';
 import { Image, type ImageRequireSource, TouchableOpacity } from 'react-native';
 
 import { styles } from './IconButton.styles';
+import { AlternateAppIcons } from 'expo-alternate-app-icons/AlternateAppIconsType';
 
 interface IconButtonProps {
   source: ImageRequireSource;
-  name: string;
-  onPress: (name: string) => void;
+  name: AlternateAppIcons;
+  onPress: (name: AlternateAppIcons) => void;
   selected: boolean;
 }
 

--- a/plugin/src/generateTypeIconsFIle.ts
+++ b/plugin/src/generateTypeIconsFIle.ts
@@ -1,0 +1,25 @@
+import path from 'path';
+import fs from 'fs';
+
+/**
+ * Generates a TypeScript file containing the `AlternateAppIcons` type.
+ * @param iconNames Array of icon names to include in the type definition.
+ */
+export function generateTypeIconsFile(iconNames: string[]): void {
+  // Path to the file to be generated
+  const typeFilePath = path.resolve(__dirname, '../../src', 'AlternateAppIconsType.ts');
+
+  // Content of the TypeScript file
+  const typeFileContent = `
+/**
+ * Auto-generated file. Do not edit manually.
+ */
+export type AlternateAppIcons = ${iconNames.map((name) => `'${name}'`).join(' | ')};
+`;
+
+  // Ensure the directory exists
+  fs.mkdirSync(path.dirname(typeFilePath), { recursive: true });
+
+  // Write the file with the generated content
+  fs.writeFileSync(typeFilePath, typeFileContent.trim());
+}

--- a/plugin/src/generateUniversalIcon.ts
+++ b/plugin/src/generateUniversalIcon.ts
@@ -3,35 +3,71 @@ import { IOSConfig } from 'expo/config-plugins';
 import { writeFile, mkdir } from 'fs/promises';
 import { join, parse } from 'path';
 
+import { AlternateIcon, iOSIconVariant } from './types';
 import { writeContentsJson } from './writeContentsJson';
 
 export async function generateUniversalIcon(
   name: string,
   projectRoot: string,
-  src: string,
+  src: AlternateIcon['ios'],
   options: { width: number; height: number },
 ) {
-  const { base: filename } = parse(src);
   const iosProjectPath = join(projectRoot, 'ios', IOSConfig.XcodeUtils.getProjectName(projectRoot));
-  const appIconSetPath = join(iosProjectPath, `Images.xcassets/${name}.appiconset`);
-  const appIconPath = join(appIconSetPath, filename);
-  const { source } = await generateImageAsync(
-    { projectRoot, cacheType: `alternate-app-icon-${name}` },
-    {
-      src,
-      name,
-      removeTransparency: true,
-      backgroundColor: '#ffffff',
-      resizeMode: 'cover',
-      width: options.width,
-      height: options.height,
-    },
-  );
-  try {
-    await mkdir(appIconSetPath, { recursive: true });
-    await writeFile(appIconPath, source);
-    await writeContentsJson(filename, appIconSetPath, options.width, options.height);
-  } catch (error) {
-    console.log(error);
+  if (typeof src === 'string') {
+    const { base: filename } = parse(src);
+    const appIconSetPath = join(iosProjectPath, `Images.xcassets/${name}.appiconset`);
+    const appIconPath = join(appIconSetPath, filename);
+    const { source } = await generateImageAsync(
+      { projectRoot, cacheType: `alternate-app-icon-${name}` },
+      {
+        src,
+        name,
+        removeTransparency: true,
+        backgroundColor: '#ffffff',
+        resizeMode: 'cover',
+        width: options.width,
+        height: options.height,
+      },
+    );
+    try {
+      await mkdir(appIconSetPath, { recursive: true });
+      await writeFile(appIconPath, source);
+      await writeContentsJson(filename, appIconSetPath, options.width, options.height);
+    } catch (error) {
+      console.log(error);
+    }
+  } else {
+    const appIconSetPath = join(iosProjectPath, `Images.xcassets/${name}.appiconset`);
+    const filenames: Record<string, string> = {};
+    for (const ico in src) {
+      let { base: filename } = parse(src[ico as iOSIconVariant]);
+      filename = filename.replace('.', `-${ico}.`);
+      filenames[ico] = filename;
+      const appIconPath = join(appIconSetPath, filename);
+      const { source } = await generateImageAsync(
+        { projectRoot, cacheType: `alternate-app-icon-${name}-${ico}` },
+        {
+          src: src[ico as iOSIconVariant],
+          name: ico,
+          removeTransparency: true,
+          backgroundColor: '#ffffff',
+          resizeMode: 'cover',
+          width: options.width,
+          height: options.height,
+        },
+      );
+      try {
+        await mkdir(appIconSetPath, { recursive: true });
+        await writeFile(appIconPath, source);
+      } catch (error) {
+        console.log(error);
+      }
+    }
+
+    try {
+      await writeContentsJson(filenames, appIconSetPath, options.width, options.height);
+    } catch (e) {
+      console.log(e);
+    }
   }
 }

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -42,6 +42,6 @@ function mapToAlternateIcon(path: string): AlternateIcon {
     ios: path,
     android: {
       foregroundImage: path,
-    }
-  }
+    },
+  };
 }

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -6,6 +6,7 @@ import { withXcodeProjectUpdate } from './withXcodeProjectUpdate';
 import { AlternateIcon } from './types';
 import { withAdaptiveIconsGenerator } from './withAdaptiveIconsGenerator';
 import { parse } from 'path';
+import { generateTypeIconsFile } from './generateTypeIconsFIle';
 
 const isPathArray = (alternateIcons: AlternateIcon[] | string[]): alternateIcons is string[] =>
   alternateIcons.some((icon) => typeof icon === 'string');
@@ -26,6 +27,7 @@ export default function withAlternateAppIcons(
   }
 
   const iconNames = alternateIcons.map((icon) => icon.name);
+  generateTypeIconsFile(iconNames);
 
   config = withAlternateAppIconsGenerator(config, alternateIcons);
   config = withXcodeProjectUpdate(config, iconNames);

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -1,10 +1,12 @@
 import type { ExpoConfig } from '@expo/config-types';
 
 type AndroidConfig = Exclude<ExpoConfig['android'], undefined>;
-type iOSIcon = string | Record<iOSIconVariant, string>;
-export type iOSIconVariant = 'light' | 'dark' | 'tinted';
+type iOSConfig = Exclude<ExpoConfig['ios'], undefined>;
+export type iOSVariantsIcon = Record<iOSVariants, string>;
+export type iOSVariants = 'light' | 'dark' | 'tinted';
+
 export type AlternateIcon = {
   name: string;
-  ios: iOSIcon;
+  ios: iOSConfig['icon'] | iOSVariantsIcon;
   android: AndroidConfig['adaptiveIcon'];
 };

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -1,10 +1,10 @@
 import type { ExpoConfig } from '@expo/config-types';
 
 type AndroidConfig = Exclude<ExpoConfig['android'], undefined>;
-type iOSConfig = Exclude<ExpoConfig['ios'], undefined>;
-
+type iOSIcon = string | Record<iOSIconVariant, string>;
+export type iOSIconVariant = 'light' | 'dark' | 'tinted';
 export type AlternateIcon = {
   name: string;
-  ios: iOSConfig['icon'];
-  android: AndroidConfig['adaptiveIcon']
-}
+  ios: iOSIcon;
+  android: AndroidConfig['adaptiveIcon'];
+};

--- a/plugin/src/withAdaptiveIconsGenerator.ts
+++ b/plugin/src/withAdaptiveIconsGenerator.ts
@@ -2,7 +2,7 @@ import {
   AndroidConfig,
   ConfigPlugin,
   withAndroidColors,
-  withDangerousMod
+  withDangerousMod,
 } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 import { AlternateIcon } from './types';
@@ -13,10 +13,10 @@ const { Colors } = AndroidConfig;
 
 export function withAdaptiveIconsGenerator(
   config: ExpoConfig,
-  alternateIcons: AlternateIcon[]
+  alternateIcons: AlternateIcon[],
 ): ExpoConfig {
   for (const alternateIcon of alternateIcons) {
-    withAndroidAdaptiveIconColors(config, alternateIcon)
+    withAndroidAdaptiveIconColors(config, alternateIcon);
   }
   return withDangerousMod(config, [
     'android',
@@ -30,7 +30,7 @@ export function withAdaptiveIconsGenerator(
         await generateAdaptiveIcon(name, projectRoot, adaptiveIcon);
       }
       return config;
-    }
+    },
   ]);
 }
 
@@ -38,7 +38,7 @@ const withAndroidAdaptiveIconColors: ConfigPlugin<AlternateIcon> = (config, alte
   return withAndroidColors(config, (config) => {
     config.modResults = Colors.assignColorValue(config.modResults, {
       value: alternateIcon.android?.backgroundColor ?? '#FFFFFF',
-      name: `iconBackground${toPascalCase(alternateIcon.name)}`
+      name: `iconBackground${toPascalCase(alternateIcon.name)}`,
     });
     return config;
   });

--- a/plugin/src/withAlternateAppIconsGenerator.ts
+++ b/plugin/src/withAlternateAppIconsGenerator.ts
@@ -1,7 +1,7 @@
 import { type ExpoConfig } from '@expo/config-types';
 import { withDangerousMod } from 'expo/config-plugins';
 
-import { generateUniversalIcon } from './generateUniversalIcon';
+import { generateUniversalIcon, generateUniversalVariantsIcon } from './generateUniversalIcon';
 import { AlternateIcon } from './types';
 
 export function withAlternateAppIconsGenerator(
@@ -15,10 +15,22 @@ export function withAlternateAppIconsGenerator(
         const { ios: iconPath, name } = alternateIcon;
         if (!iconPath) break;
         const projectRoot = config.modRequest.projectRoot;
-        await generateUniversalIcon(name, projectRoot, iconPath, {
-          width: 1024,
-          height: 1024,
-        });
+
+        if (typeof iconPath === 'string') {
+          await generateUniversalIcon(name, projectRoot, iconPath, {
+            width: 1024,
+            height: 1024,
+          });
+        } else if (iconPath?.dark != null && iconPath?.light != null && iconPath?.tinted != null) {
+          await generateUniversalVariantsIcon(name, projectRoot, iconPath, {
+            width: 1024,
+            height: 1024,
+          });
+        } else {
+          throw new Error(
+            `Invalid alternate icon configuration for "${alternateIcon.name}". Ensure the iconPath is either a string for a single icon or an object containing "dark", "light", and "tinted" variants.`,
+          );
+        }
       }
 
       return config;

--- a/plugin/src/withAndroidManifestUpdate.ts
+++ b/plugin/src/withAndroidManifestUpdate.ts
@@ -10,16 +10,13 @@ const { default: renderIntentFilters, getIntentFilters } = AndroidConfig.IntentF
 type ActivityAlias = AndroidConfig.Manifest.ManifestActivity;
 
 type ApplicationWithAliases = AndroidConfig.Manifest.ManifestApplication & {
-  ['activity-alias']?: ActivityAlias[],
-}
+  ['activity-alias']?: ActivityAlias[];
+};
 
-export function withAndroidManifestUpdate(
-  config: ExpoConfig,
-  alternateIconNames: string[],
-) {
+export function withAndroidManifestUpdate(config: ExpoConfig, alternateIconNames: string[]) {
   const intentFilters = getIntentFilters(config);
 
-  config = withAndroidManifest(config, (config, ) => {
+  config = withAndroidManifest(config, (config) => {
     const mainApplication = getMainApplicationOrThrow(config.modResults);
 
     for (const name of alternateIconNames) {
@@ -52,11 +49,11 @@ function addActivityAliasToMainApplication(
       },
       ...renderIntentFilters(intentFilters ?? []),
     ],
-  }
+  };
 
   if (mainApplication['activity-alias']) {
     const currentIndex = mainApplication['activity-alias'].findIndex(
-      (e: any) => e.$['android:name'] === activityAlias.$['android:name']
+      (e: any) => e.$['android:name'] === activityAlias.$['android:name'],
     );
     if (currentIndex >= 0) {
       mainApplication['activity-alias'][currentIndex] = activityAlias;

--- a/plugin/src/writeContentsJson.ts
+++ b/plugin/src/writeContentsJson.ts
@@ -2,7 +2,7 @@ import { writeFile } from 'fs/promises';
 import { join } from 'path';
 
 export async function writeContentsJson(
-  filename: string | Record<string, string>,
+  filename: string,
   assetPath: string,
   width: number,
   height: number,
@@ -10,31 +10,14 @@ export async function writeContentsJson(
   const path = join(assetPath, 'Contents.json');
   const payload = JSON.stringify(
     {
-      images:
-        typeof filename === 'string'
-          ? [
-              {
-                filename,
-                idiom: 'universal',
-                platform: 'ios',
-                size: `${width}x${height}`,
-              },
-            ]
-          : Object.entries(filename).map(([type, name]) => ({
-              filename: name,
-              idiom: 'universal',
-              platform: 'ios',
-              size: `${width}x${height}`,
-              appearances:
-                type !== 'light'
-                  ? [
-                      {
-                        appearance: 'luminosity',
-                        value: type,
-                      },
-                    ]
-                  : undefined,
-            })),
+      images: [
+        {
+          filename,
+          idiom: 'universal',
+          platform: 'ios',
+          size: `${width}x${height}`,
+        },
+      ],
       info: {
         author: 'expo',
         version: 1,
@@ -44,5 +27,40 @@ export async function writeContentsJson(
     2,
   );
 
+  await writeFile(path, payload, 'utf-8');
+}
+
+export async function writeVariantsContentsJson(
+  filenames: Record<string, string>,
+  assetPath: string,
+  width: number,
+  height: number,
+) {
+  const path = join(assetPath, 'Contents.json');
+  const payload = JSON.stringify(
+    {
+      images: Object.entries(filenames).map(([type, name]) => ({
+        filename: name,
+        idiom: 'universal',
+        platform: 'ios',
+        size: `${width}x${height}`,
+        appearances:
+          type !== 'light'
+            ? [
+                {
+                  appearance: 'luminosity',
+                  value: type,
+                },
+              ]
+            : undefined,
+      })),
+      info: {
+        author: 'expo',
+        version: 1,
+      },
+    },
+    null,
+    2,
+  );
   await writeFile(path, payload, 'utf-8');
 }

--- a/plugin/src/writeContentsJson.ts
+++ b/plugin/src/writeContentsJson.ts
@@ -2,7 +2,7 @@ import { writeFile } from 'fs/promises';
 import { join } from 'path';
 
 export async function writeContentsJson(
-  filename: string,
+  filename: string | Record<string, string>,
   assetPath: string,
   width: number,
   height: number,
@@ -10,14 +10,31 @@ export async function writeContentsJson(
   const path = join(assetPath, 'Contents.json');
   const payload = JSON.stringify(
     {
-      images: [
-        {
-          filename,
-          idiom: 'universal',
-          platform: 'ios',
-          size: `${width}x${height}`,
-        },
-      ],
+      images:
+        typeof filename === 'string'
+          ? [
+              {
+                filename,
+                idiom: 'universal',
+                platform: 'ios',
+                size: `${width}x${height}`,
+              },
+            ]
+          : Object.entries(filename).map(([type, name]) => ({
+              filename: name,
+              idiom: 'universal',
+              platform: 'ios',
+              size: `${width}x${height}`,
+              appearances:
+                type !== 'light'
+                  ? [
+                      {
+                        appearance: 'luminosity',
+                        value: type,
+                      },
+                    ]
+                  : undefined,
+            })),
       info: {
         author: 'expo',
         version: 1,

--- a/src/AlternateAppIconsType.ts
+++ b/src/AlternateAppIconsType.ts
@@ -1,0 +1,1 @@
+export type AlternateAppIcons = string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import ExpoAlternateAppIconsModule from './ExpoAlternateAppIconsModule';
-
+import { AlternateAppIcons } from './AlternateAppIconsType';
 /**
  * A boolean value indicating whether the current device supports alternate app icons.
  *
@@ -29,7 +29,8 @@ export const supportsAlternateIcons: boolean = ExpoAlternateAppIconsModule.suppo
  * // Reset to the default app icon.
  * const resetResult = await setAlternateAppIcon(null);
  */
-export async function setAlternateAppIcon(name: string | null): Promise<string | null> {
+
+export async function setAlternateAppIcon(name: AlternateAppIcons | null): Promise<string | null> {
   return ExpoAlternateAppIconsModule.setAlternateAppIcon(name);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import ExpoAlternateAppIconsModule from './ExpoAlternateAppIconsModule';
-import { AlternateAppIcons } from './AlternateAppIconsType';
+import { type AlternateAppIcons } from './AlternateAppIconsType';
+export { type AlternateAppIcons } from './AlternateAppIconsType';
+
 /**
  * A boolean value indicating whether the current device supports alternate app icons.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-import ExpoAlternateAppIconsModule from './ExpoAlternateAppIconsModule';
 import { type AlternateAppIcons } from './AlternateAppIconsType';
+import ExpoAlternateAppIconsModule from './ExpoAlternateAppIconsModule';
+
 export { type AlternateAppIcons } from './AlternateAppIconsType';
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export async function setAlternateAppIcon(name: AlternateAppIcons | null): Promi
  * const iconName = getAppIconName();
  * console.log(`The active app icon is: ${iconName}`);
  */
-export function getAppIconName(): string | null {
+export function getAppIconName(): AlternateAppIcons | null {
   return ExpoAlternateAppIconsModule.getAppIconName();
 }
 


### PR DESCRIPTION
This pull request introduces a new feature to the expo-alternate-app-icon library, allowing developers to define dark and tinted variants for alternate app icons on iOS.

This PR closes #116 and closes #15.