### PR TITLE
feat(ios): add liquid glass `.icon` support

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -23,7 +23,7 @@ export default function withAlternateAppIcons(
   generateTypeIconsFile(iconNames);
 
   config = withAlternateAppIconsGenerator(config, alternateIcons);
-  config = withXcodeProjectUpdate(config, iconNames);
+  config = withXcodeProjectUpdate(config, alternateIcons);
   config = withAdaptiveIconsGenerator(config, alternateIcons);
   config = withAndroidManifestUpdate(config, iconNames);
 

--- a/plugin/src/ios/addLiquidGlassIcon.ts
+++ b/plugin/src/ios/addLiquidGlassIcon.ts
@@ -1,4 +1,4 @@
-import { IOSConfig } from 'expo/config-plugins';
+import { IOSConfig, WarningAggregator } from 'expo/config-plugins';
 import { cp } from 'fs/promises';
 import { join } from 'path';
 
@@ -14,6 +14,9 @@ export async function addLiquidGlassIcon(
   try {
     await cp(iconPath, appIconPath, { recursive: true });
   } catch (error) {
-    console.log(error);
+    WarningAggregator.addWarningIOS(
+      'expo-alternate-app-icons',
+      `Failed to copy liquid glass icon "${name}": ${error}`,
+    );
   }
 }

--- a/plugin/src/ios/addLiquidGlassIcon.ts
+++ b/plugin/src/ios/addLiquidGlassIcon.ts
@@ -1,0 +1,19 @@
+import { IOSConfig } from 'expo/config-plugins';
+import { cp } from 'fs/promises';
+import { join } from 'path';
+
+export async function addLiquidGlassIcon(
+  name: string,
+  projectRoot: string,
+  src: string,
+): Promise<void> {
+  const iosProjectPath = join(projectRoot, 'ios', IOSConfig.XcodeUtils.getProjectName(projectRoot));
+  const appIconPath = join(iosProjectPath, `${name}.icon`);
+  const iconPath = join(projectRoot, src);
+
+  try {
+    await cp(iconPath, appIconPath, { recursive: true });
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/plugin/src/ios/withAlternateAppIconsGenerator.ts
+++ b/plugin/src/ios/withAlternateAppIconsGenerator.ts
@@ -1,6 +1,8 @@
 import { type ExpoConfig } from '@expo/config-types';
 import { withDangerousMod } from 'expo/config-plugins';
+import { extname } from 'path';
 
+import { addLiquidGlassIcon } from './addLiquidGlassIcon';
 import { generateUniversalIcon, generateUniversalVariantsIcon } from './generateUniversalIcon';
 import { type AlternateIcon } from '../types';
 import { isIosVariantsIcon } from '../utils';
@@ -18,10 +20,14 @@ export function withAlternateAppIconsGenerator(
         const projectRoot = config.modRequest.projectRoot;
 
         if (typeof iconPath === 'string') {
-          await generateUniversalIcon(name, projectRoot, iconPath, {
-            width: 1024,
-            height: 1024,
-          });
+          if (extname(iconPath) === '.icon') {
+            await addLiquidGlassIcon(name, projectRoot, iconPath);
+          } else {
+            await generateUniversalIcon(name, projectRoot, iconPath, {
+              width: 1024,
+              height: 1024,
+            });
+          }
         } else if (isIosVariantsIcon(iconPath)) {
           await generateUniversalVariantsIcon(name, projectRoot, iconPath, {
             width: 1024,

--- a/plugin/src/ios/withXcodeProjectUpdate.ts
+++ b/plugin/src/ios/withXcodeProjectUpdate.ts
@@ -1,17 +1,44 @@
 import { type ExpoConfig } from '@expo/config-types';
-import { withXcodeProject } from 'expo/config-plugins';
+import { IOSConfig, withXcodeProject } from 'expo/config-plugins';
+import { extname } from 'path';
+
+import { type AlternateIcon } from '../types';
 
 const ALTERNATE_APP_ICONS_NAMES_PROPERTY = 'ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES';
 
+function addIconFileToProject(project: any, projectName: string, iconName: string): void {
+  const iconPath = `${iconName}.icon`;
+
+  IOSConfig.XcodeUtils.addResourceFileToGroup({
+    filepath: `${projectName}/${iconPath}`,
+    groupName: projectName,
+    project,
+    isBuildFile: true,
+    verbose: true,
+  });
+}
+
 export function withXcodeProjectUpdate(
   config: ExpoConfig,
-  alternateAppIconNames: string[],
+  alternateIcons: AlternateIcon[],
 ): ExpoConfig {
   config = withXcodeProject(config, (config) => {
+    const alternateAppIconNames = alternateIcons.map((icon) => icon.name);
+    const projectName = config.modRequest.projectName;
+
     config.modResults.updateBuildProperty(
       ALTERNATE_APP_ICONS_NAMES_PROPERTY,
       alternateAppIconNames,
     );
+
+    if (projectName) {
+      for (const icon of alternateIcons) {
+        // add liquid glass icon to the Xcode project
+        if (typeof icon.ios === 'string' && extname(icon.ios) === '.icon') {
+          addIconFileToProject(config.modResults, projectName, icon.name);
+        }
+      }
+    }
 
     return config;
   });

--- a/plugin/src/ios/withXcodeProjectUpdate.ts
+++ b/plugin/src/ios/withXcodeProjectUpdate.ts
@@ -1,22 +1,10 @@
 import { type ExpoConfig } from '@expo/config-types';
-import { IOSConfig, withXcodeProject } from 'expo/config-plugins';
+import { IOSConfig, withXcodeProject, type XcodeProject } from 'expo/config-plugins';
 import { extname } from 'path';
 
 import { type AlternateIcon } from '../types';
 
 const ALTERNATE_APP_ICONS_NAMES_PROPERTY = 'ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES';
-
-function addIconFileToProject(project: any, projectName: string, iconName: string): void {
-  const iconPath = `${iconName}.icon`;
-
-  IOSConfig.XcodeUtils.addResourceFileToGroup({
-    filepath: `${projectName}/${iconPath}`,
-    groupName: projectName,
-    project,
-    isBuildFile: true,
-    verbose: true,
-  });
-}
 
 export function withXcodeProjectUpdate(
   config: ExpoConfig,
@@ -44,4 +32,16 @@ export function withXcodeProjectUpdate(
   });
 
   return config;
+}
+
+function addIconFileToProject(project: XcodeProject, projectName: string, iconName: string): void {
+  const iconPath = `${iconName}.icon`;
+
+  IOSConfig.XcodeUtils.addResourceFileToGroup({
+    filepath: `${projectName}/${iconPath}`,
+    groupName: projectName,
+    project,
+    isBuildFile: true,
+    verbose: true,
+  });
 }


### PR DESCRIPTION
# Description

Add support for iOS Liquid Glass `.icon` files created with Apple’s Icon Composer.

### Usage

```ts
ios: './path/to/file.icon'
```

### Changes

- `plugin/src/ios/withAlternateAppIconsGenerator.ts`: Detect the `.icon` extension and call `addLiquidGlassIcon`
- `plugin/src/ios/addLiquidGlassIcon.ts`: Copy the `.icon` (which is a directory) into `iosProjectPath`
- `plugin/src/ios/withXcodeProjectUpdate.ts`: Add the copied `.icon` to Xcode project
- `plugin/src/index.ts`: Pass `alternateIcons` instead of `iconNames` to `withXcodeProjectUpdate`, so `.icon` can be detected and copied conditionally

> Reference: [expo prebuild-config source](https://github.com/expo/expo/blob/ba34f955aead270e5dac8a76e601220bd61845c5/packages/%40expo/prebuild-config/src/plugins/icons/withIosIcons.ts)

## Related Tickets/Issues

Solved [#187](https://github.com/pchalupa/expo-alternate-app-icons/issues/187)

## I have tested my change on

### iOS

- [x] Mobile simulator
- [x] Mobile device

### Android

- [ ] Mobile simulator
- [ ] Mobile device

I have tested static, variant, and the new Liquid Glass icons on both iOS devices and simulators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for alternate iOS app icons in the `.icon` file format for advanced icon customization.
  * Automatic handling and inclusion of `.icon` assets into iOS builds so alternate icons are integrated during project updates while preserving standard icon behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pchalupa/expo-alternate-app-icons/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->