### PR TITLE
fix(android): fix Android MainActivity deep links/intent issue

### DIFF
--- a/android/src/main/java/expo/modules/alternateappicons/ExpoAlternateAppIconsModule.kt
+++ b/android/src/main/java/expo/modules/alternateappicons/ExpoAlternateAppIconsModule.kt
@@ -77,7 +77,20 @@ class ExpoAlternateAppIconsModule : Module() {
         PackageManager.GET_ACTIVITIES or PackageManager.GET_DISABLED_COMPONENTS
       )
       
-      packageInfo.activities?.forEach { activityInfo ->
+      // Prevent unknown icon failures
+      val aliasActivities = packageInfo.activities?.filter { activityInfo ->
+        val name = activityInfo.name.split('.').last()
+        name != MAIN_ACTIVITY_NAME && name.startsWith(MAIN_ACTIVITY_NAME)
+      }
+      .orEmpty()
+      val targetExists = aliasActivities.any {
+        it.name.split('.').last() == targetAliasName
+      }
+      if (!targetExists) {
+        throw IllegalArgumentException("Unknown app icon alias: $icon")
+      }
+
+      aliasActivities.forEach { activityInfo ->
         val name = activityInfo.name.split('.').last()
         
         // Never disable MainActivity
@@ -106,4 +119,5 @@ class ExpoAlternateAppIconsModule : Module() {
 
     return@withContext if (icon == "Default") null else icon
   }
+
 }

--- a/android/src/main/java/expo/modules/alternateappicons/ExpoAlternateAppIconsModule.kt
+++ b/android/src/main/java/expo/modules/alternateappicons/ExpoAlternateAppIconsModule.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 const val MAIN_ACTIVITY_NAME = "MainActivity"
+const val DEFAULT_ALIAS_NAME = "MainActivityDefault"
 
 class ExpoAlternateAppIconsModule : Module() {
   override fun definition() = ModuleDefinition {
@@ -23,50 +24,86 @@ class ExpoAlternateAppIconsModule : Module() {
   }
 
   private fun getAppIconName(): String? {
-    val currentActivityComponent = appContext.activityProvider?.currentActivity?.componentName ?: return null
+    val pm = appContext.reactContext?.packageManager ?: return null
+    val packageName = appContext.reactContext?.packageName ?: return null
 
-    return try {
-      retrieveIconNameFromComponent(currentActivityComponent)
-    } catch (error: PackageManager.NameNotFoundException) {
-      null
+    try {
+      // Query all activities to find the currently enabled one
+      // Current activity will be MainActivity if opened from deep-link/shortcuts, is not reflect current app icon
+      val packageInfo = pm.getPackageInfo(
+        packageName, 
+        PackageManager.GET_ACTIVITIES or PackageManager.GET_DISABLED_COMPONENTS
+      )
+      
+      packageInfo.activities?.forEach { activityInfo ->
+        val name = activityInfo.name.split('.').last()
+        
+        // Skip the base MainActivity (always enabled)
+        if (name == MAIN_ACTIVITY_NAME) return@forEach
+        
+        if (name.startsWith(MAIN_ACTIVITY_NAME)) {
+          val componentName = ComponentName(packageName, activityInfo.name)
+          val state = pm.getComponentEnabledSetting(componentName)
+          
+          if (state == PackageManager.COMPONENT_ENABLED_STATE_ENABLED) {
+            if (name == DEFAULT_ALIAS_NAME) return null
+            return name.substring(MAIN_ACTIVITY_NAME.length)
+          } else if (name == DEFAULT_ALIAS_NAME && state == PackageManager.COMPONENT_ENABLED_STATE_DEFAULT) {
+            // Default alias is implicitly enabled at first
+            return null
+          }
+        }
+      }
+    } catch (e: Exception) {
+      e.printStackTrace()
     }
+    return null
   }
 
   private suspend fun setAlternateAppIcon(icon: String?): String? = withContext(Dispatchers.Main) {
-    val currentActivityComponent = appContext.activityProvider!!.currentActivity!!.componentName
+    val pm = appContext.reactContext?.packageManager ?: return@withContext icon
+    val packageName = appContext.reactContext?.packageName ?: return@withContext icon
 
-    val currentIconName = retrieveIconNameFromComponent(currentActivityComponent)
-
-    if (currentIconName == icon) return@withContext icon
-
-    val newActivityComponent = replaceMainActivitySimpleName(currentActivityComponent, icon)
-
-    appContext.reactContext?.packageManager?.run {
-      setComponentEnabledSetting(newActivityComponent, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP)
-      setComponentEnabledSetting(currentActivityComponent, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP)
+    // Map null to "Default", targets MainActivityDefault
+    val targetAliasName = if (icon == null || icon == "Default") {
+      DEFAULT_ALIAS_NAME
+    } else {
+      "$MAIN_ACTIVITY_NAME$icon"
     }
 
-    return@withContext icon
-  }
+    try {
+      val packageInfo = pm.getPackageInfo(
+        packageName, 
+        PackageManager.GET_ACTIVITIES or PackageManager.GET_DISABLED_COMPONENTS
+      )
+      
+      packageInfo.activities?.forEach { activityInfo ->
+        val name = activityInfo.name.split('.').last()
+        
+        // Never disable MainActivity
+        if (name == MAIN_ACTIVITY_NAME) return@forEach
+        
+        val componentName = ComponentName(packageName, activityInfo.name)
 
-  private fun getSimpleName(component: ComponentName): String = component.className.split('.').last()
-
-  private fun retrieveIconNameFromComponent(component: ComponentName): String? =
-    with(getSimpleName(component)) {
-      when  {
-        equals(MAIN_ACTIVITY_NAME) -> null
-        startsWith(MAIN_ACTIVITY_NAME) -> substring(MAIN_ACTIVITY_NAME.length)
-        else -> null
+        // Enable the target, disable all other aliases
+        if (name == targetAliasName) {
+          pm.setComponentEnabledSetting(
+            componentName,
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+            PackageManager.DONT_KILL_APP
+          )
+        } else if (name.startsWith(MAIN_ACTIVITY_NAME)) {
+          pm.setComponentEnabledSetting(
+            componentName,
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            PackageManager.DONT_KILL_APP
+          )
+        }
       }
+    } catch (e: Exception) {
+      e.printStackTrace()
     }
 
-  private fun replaceMainActivitySimpleName(component: ComponentName, suffix: String?): ComponentName {
-    val newActivitySimpleName = "$MAIN_ACTIVITY_NAME${suffix ?: ""}"
-    val identifiers = component.className.split('.').toMutableList()
-    identifiers[identifiers.size - 1] = newActivitySimpleName
-    val packageName = component.packageName
-    val newActivityName = identifiers.joinToString(".")
-    return ComponentName(packageName, newActivityName)
+    return@withContext if (icon == "Default") null else icon
   }
-
 }

--- a/plugin/src/android/withAndroidManifestUpdate.ts
+++ b/plugin/src/android/withAndroidManifestUpdate.ts
@@ -39,6 +39,9 @@ export function withAndroidManifestUpdate(config: ExpoConfig, alternateIconNames
 
     // Add alternate aliases (alternate app icons)
     for (const name of alternateIconNames) {
+      if (toPascalCase(name) === 'Default') {
+        throw new Error('Alternate icon name "Default" is reserved.');
+      }
       addActivityAliasToMainApplication(mainApplication, name, intentFilters, false);
     }
 

--- a/plugin/src/android/withAndroidManifestUpdate.ts
+++ b/plugin/src/android/withAndroidManifestUpdate.ts
@@ -5,7 +5,7 @@ import { toPascalCase, toSnakeCase } from '../utils';
 
 type AndroidIntentFilters = NonNullable<Android['intentFilters']>;
 
-const { getMainApplicationOrThrow } = AndroidConfig.Manifest;
+const { getMainApplicationOrThrow, getMainActivityOrThrow } = AndroidConfig.Manifest;
 const { default: renderIntentFilters, getIntentFilters } = AndroidConfig.IntentFilters;
 
 type ActivityAlias = AndroidConfig.Manifest.ManifestActivity;
@@ -18,10 +18,28 @@ export function withAndroidManifestUpdate(config: ExpoConfig, alternateIconNames
   const intentFilters = getIntentFilters(config);
 
   config = withAndroidManifest(config, (config) => {
-    const mainApplication = getMainApplicationOrThrow(config.modResults);
+    const mainApplication = getMainApplicationOrThrow(config.modResults) as ApplicationWithAliases;
+    const mainActivity = getMainActivityOrThrow(config.modResults);
 
+    // Remove MAIN, LAUNCHER from the base MainActivity (not show icon, never be disabled)
+    if (mainActivity['intent-filter']) {
+      mainActivity['intent-filter'] = mainActivity['intent-filter'].filter((intentFilter: any) => {
+        const isMain = intentFilter.action?.some(
+          (a: any) => a.$['android:name'] === 'android.intent.action.MAIN',
+        );
+        const isLauncher = intentFilter.category?.some(
+          (c: any) => c.$['android:name'] === 'android.intent.category.LAUNCHER',
+        );
+        return !(isMain && isLauncher);
+      });
+    }
+
+    // Add default alias (default app icon, can safely be disabled)
+    addActivityAliasToMainApplication(mainApplication, 'Default', intentFilters, true);
+
+    // Add alternate aliases (alternate app icons)
     for (const name of alternateIconNames) {
-      addActivityAliasToMainApplication(mainApplication, name, intentFilters);
+      addActivityAliasToMainApplication(mainApplication, name, intentFilters, false);
     }
 
     return config;
@@ -34,13 +52,14 @@ function addActivityAliasToMainApplication(
   mainApplication: ApplicationWithAliases,
   iconName: string,
   intentFilters?: AndroidIntentFilters,
+  isDefaultAlias: boolean = false,
 ) {
   const activityAlias: ActivityAlias = {
     $: {
       'android:name': `.MainActivity${toPascalCase(iconName)}`,
-      'android:enabled': 'false',
+      'android:enabled': isDefaultAlias ? 'true' : 'false',
       'android:exported': 'true',
-      'android:icon': `@mipmap/ic_launcher_${toSnakeCase(iconName)}`,
+      ...(!isDefaultAlias && { 'android:icon': `@mipmap/ic_launcher_${toSnakeCase(iconName)}` }),
       'android:targetActivity': '.MainActivity',
     },
     'intent-filter': [


### PR DESCRIPTION
# Description

This fixes an issue where the app could not be launched via **deep links or shortcuts (quick actions)** on Android after applying an alternate icon.

<img width="788" height="37" alt="Screenshot 2026-05-24 at 05 14 31 copy" src="https://github.com/user-attachments/assets/02a951e2-8318-489e-9cf7-a89bd489e4d8" />
(Example of expo deep links error when alternate icon is applied)

---

The issue occurs because `MainActivity` is disabled to hide the default icon. However, Android completely disables the component when this happens, causing every `<intent-filter>` within it to be ignored by the system. As a result, all intents and URI schemes defined in MainActivity are also disabled, preventing deep links and shortcuts from launching the app.

To resolve this, `MainActivity` **MUST NOT** be disabled. Instead, it should remain as an always-on base activity that is independent of launcher icon state. App icons will be managed through a "Default" and "Alternate" aliases instead.

<img width="1128" height="431" alt="Screenshot 2026-05-25 at 07 14 21" src="https://github.com/user-attachments/assets/cf0718d8-53b5-4ac0-b315-13738a66852e" />

### Changes

* `withAndroidManifestUpdate.ts`
    * Remove `MAIN` and `LAUNCHER` from the base `MainActivity` to keep this icon hidden when always `enabled="true"`. (default icon will refer to `MainActivityDefault` alias instead)
    * Add a `MainActivityDefault` alias to serve as the default app icon. This alias can be safely disabled without affecting `MainActivity` usability, is enabled by default. The launcher icon will reference this alias, and changing the app icon will disable this alias instead.
    * Example result of `AndroidManifest.xml` in the above image.

* `ExpoAlternateAppIconsModule.kt`
    * Rewrite `getAppIconName` to determine the enabled alias (excluding `MainActivity`) instead of relying on the current activity, which may be `MainActivity` when the app is opened via deep links or shortcuts, which does not accurately reflect the active app icon. And map the `"Default"` activity to a `null` icon.
    * Rewrite `setAlternateAppIcon` to switch icons by enabling/disabling aliases without touching `MainActivity`. And map a `null` icon to the `"Default"` activity.
    * _Note: These functions have been fully rewritten for more reliable activity handling and to eliminate unexpected behavior, which I’ve already tested on both mobile device and simulator._

## Related Tickets/Issues

Fixed [#260](https://github.com/pchalupa/expo-alternate-app-icons/issues/260)

## I have tested my change on

### iOS

- [ ] Mobile simulator
- [ ] Mobile device

### Android

- [x] Mobile simulator
- [x] Mobile device

Now, deep links and shortcuts will always work, regardless of which app icon is active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds reliable support for a "Default" app icon alias and ensures alternate icons are registered so users can choose them.
* **Bug Fixes**
  * Improves detection and switching between default and alternate app icons, rejects unknown alias names, and preserves correct launcher behavior so the app icon updates reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pchalupa/expo-alternate-app-icons/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->